### PR TITLE
Separate source and test. New analyzer counts lines in all file types.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 target
+/bin/
+/lib_managed/
+/.settings/
+/.cache-main
+/.cache-tests
+/.classpath
+/.project

--- a/build.sbt
+++ b/build.sbt
@@ -6,10 +6,20 @@ organization := "com.orrsella"
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 
-scalacOptions ++= Seq("-feature")
+libraryDependencies += "commons-io" % "commons-io" % "2.6"
+
+libraryDependencies += "org.apache.tika" % "tika-core" % "1.21"
+
+// libraryDependencies += "org.apache.tika" % "tika-parsers" % "1.21"
+
+
+retrieveManaged := true
+scalaVersion := "2.12.6"
+
+scalacOptions ++= Seq("-feature", "-language:implicitConversions" )
 
 // publishing
-crossSbtVersions := Vector("0.13.16", "1.0.1")
+// crossSbtVersions := Vector("0.13.16", "1.0.1")
 
 publishTo := {
   val nexus = "https://oss.sonatype.org/"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.1
+sbt.version=1.2.7

--- a/src/main/scala/com/orrsella/sbtstats/Analyzer.scala
+++ b/src/main/scala/com/orrsella/sbtstats/Analyzer.scala
@@ -19,5 +19,5 @@ package com.orrsella.sbtstats
 import java.io.File
 
 abstract class Analyzer {
-  def analyze(sources: Seq[File], packageBin: File, encoding: String): AnalyzerResult
+  def analyze(title: String, sources: Seq[File], packageBin: File, encoding: String): AnalyzerResult
 }

--- a/src/main/scala/com/orrsella/sbtstats/AnalyzerResult.scala
+++ b/src/main/scala/com/orrsella/sbtstats/AnalyzerResult.scala
@@ -22,7 +22,10 @@ abstract class AnalyzerResult {
   def title: String
   def metrics: Seq[AnalyzerMetric]
 
-  override def toString = title + "\n- " + metrics.mkString("\n- ") + "\n"
+  private lazy val orderedMetrics = metrics.sortBy { m => m.value }.reverse
+
+  override def toString = title + "\n- " + orderedMetrics.mkString("\n- ") + "\n"
+
   private implicit def anyToString(x: Any) = x.toString
 
   def +(that: AnalyzerResult): AnalyzerResult = {

--- a/src/main/scala/com/orrsella/sbtstats/CharsAnalyzer.scala
+++ b/src/main/scala/com/orrsella/sbtstats/CharsAnalyzer.scala
@@ -20,23 +20,28 @@ import java.io.File
 import scala.io.Source
 
 class CharsAnalyzer extends Analyzer {
-  def analyze(sources: Seq[File], packageBin: File, encoding: String) = {
+  override def analyze(title: String, sources: Seq[File], packageBin: File, encoding: String) = {
     val lines: Seq[Line] = for {
       file <- sources
-      line <- Source.fromFile(file, encoding).getLines
+      line <- Source.fromFile(file, "iso-8859-1").getLines
     } yield new Line(line)
 
     val totalChars = lines.map(_.length).foldLeft(0)(_ + _)
     val codeChars = lines.filter(_.isCode).map(_.length).foldLeft(0)(_ + _)
     val commentChars = lines.filter(_.isComment).map(_.length).foldLeft(0)(_ + _)
 
-    new CharAnalyzerResult(totalChars, codeChars, commentChars)
+    new CharAnalyzerResult(title, totalChars, codeChars, commentChars)
   }
 }
 
-class CharAnalyzerResult(totalChars: Int, codeChars: Int, commentChars: Int) extends AnalyzerResult {
+class CharAnalyzerResult(
+  titleArg: String,
+  totalChars: Int,
+  codeChars: Int,
+  commentChars: Int) extends AnalyzerResult {
 
-  val title = "Characters"
+  override val title = "Chars " + titleArg
+
   val metrics =
     Seq(
       new AnalyzerMetric("Total:     ", totalChars, "chars"),

--- a/src/main/scala/com/orrsella/sbtstats/FilesAnalyzer.scala
+++ b/src/main/scala/com/orrsella/sbtstats/FilesAnalyzer.scala
@@ -20,29 +20,31 @@ import java.io.File
 import scala.io.Source
 
 class FilesAnalyzer extends Analyzer {
-  def analyze(sources: Seq[File], packageBin: File, encoding: String) = {
+  override def analyze(title: String, sources: Seq[File], packageBin: File, encoding: String) = {
     val scalaFiles = sources.filter(_.getName.endsWith("scala")).length
     val javaFiles = sources.filter(_.getName.endsWith("java")).length
     val totalSize = sources.map(_.length).foldLeft(0l)(_ + _)
     val avgSize = if (sources.length == 0) 0 else totalSize / sources.length
     val avgLines =
       if (sources.length == 0) 0
-      else sources.map(s => Source.fromFile(s, encoding).getLines.length).foldLeft(0)(_ + _) / sources.length
+      else sources.map(Source.fromFile(_, "iso-8859-1").getLines.length).foldLeft(0)(_ + _) / sources.length
 
-    new FilesAnalyzerResult(sources.length, scalaFiles, javaFiles, totalSize, avgSize, avgLines)
+    new FilesAnalyzerResult(title, sources.length, scalaFiles, javaFiles, totalSize, avgSize, avgLines)
   }
 }
 
 class FilesAnalyzerResult(
-    totalFiles: Int,
-    scalaFiles: Int,
-    javaFiles: Int,
-    totalSize: Long,
-    avgSize: Long,
-    avgLines: Int)
+  titleArg: String,
+  totalFiles: Int,
+  scalaFiles: Int,
+  javaFiles: Int,
+  totalSize: Long,
+  avgSize: Long,
+  avgLines: Int)
   extends AnalyzerResult {
 
-  val title = "Files"
+  override val title = "Files " + titleArg
+
   val metrics =
     Seq(
       new AnalyzerMetric("Total:     ", totalFiles, "files"),

--- a/src/main/scala/com/orrsella/sbtstats/LinesAnalyzer.scala
+++ b/src/main/scala/com/orrsella/sbtstats/LinesAnalyzer.scala
@@ -20,10 +20,10 @@ import java.io.File
 import scala.io.Source
 
 class LinesAnalyzer extends Analyzer {
-  def analyze(sources: Seq[File], packageBin: File, encoding: String) = {
+  def analyze(title: String, sources: Seq[File], packageBin: File, encoding: String) = {
     val lines: Seq[Line] = for {
       file <- sources
-      line <- Source.fromFile(file, encoding).getLines
+      line <- Source.fromFile(file, "iso-8859-1").getLines
     } yield new Line(line)
 
     val totalLines = lines.length
@@ -33,19 +33,21 @@ class LinesAnalyzer extends Analyzer {
     val blankLines = lines.filter(_.isBlank).length
     //val avgLength = lines.filter(_.isCode).map(_.length).foldLeft(0)(_ + _) / totalLines // check that totalLines is not 0
 
-    new LinesAnalyzerResult(totalLines, codeLines, commentLines, bracketLines, blankLines)
+    new LinesAnalyzerResult(title, totalLines, codeLines, commentLines, bracketLines, blankLines)
   }
 }
 
 class LinesAnalyzerResult(
-    totalLines: Int,
-    codeLines: Int,
-    commentLines: Int,
-    bracketLines: Int,
-    blankLines: Int)
+  titleArg: String,
+  totalLines: Int,
+  codeLines: Int,
+  commentLines: Int,
+  bracketLines: Int,
+  blankLines: Int)
   extends AnalyzerResult {
 
-  val title = "Lines"
+  override val title = "Lines " + titleArg
+
   val metrics =
     Seq(
       new AnalyzerMetric("Total:     ", totalLines, "lines"),
@@ -53,5 +55,5 @@ class LinesAnalyzerResult(
       new AnalyzerMetric("Comment:   ", commentLines, totalLines, "lines"),
       new AnalyzerMetric("Blank:     ", blankLines, totalLines, "lines"),
       new AnalyzerMetric("Bracket:   ", bracketLines, totalLines, "lines"))
-      // new AnalyzerMetric("Avg length:", avgLength, "characters (code lines only, not inc spaces)"))
+  // new AnalyzerMetric("Avg length:", avgLength, "characters (code lines only, not inc spaces)"))
 }

--- a/src/main/scala/com/orrsella/sbtstats/LinesAnalyzer2.scala
+++ b/src/main/scala/com/orrsella/sbtstats/LinesAnalyzer2.scala
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2013 Orr Sella
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.orrsella.sbtstats
+
+import java.io.File
+import scala.io.Source
+import org.apache.commons.io.FilenameUtils
+
+/**
+ * Lines count analyzer that measures every kind of file.
+ *
+ * Only works if files are stored in ascii-based encodings.
+ *
+ * Does not try to understand when lines are blank, comments, etc.
+ */
+class LinesAnalyzer2 extends Analyzer {
+
+  def analyze(title: String, sources: Seq[File], packageBin: File, encoding: String) = {
+    val withExt = sources.map { f =>
+      val s = f.toString()
+      if (s.endsWith(".tdml.xml")) // double extension .tdml.xml used in some places.
+        ("tdml", f)
+      else
+        (FilenameUtils.getExtension(f.toString()), f)
+    }
+    val grouped = withExt.groupBy { _._1 }
+    val byExt = grouped.map {
+      case (key, listPairs) =>
+        val files = listPairs.map { _._2 }
+        val lines = files.map { f =>
+          val csName = "ISO-8859-1" // will work to count lines for all ascii-based encodings.
+          val count = Source.fromFile(f, csName).getLines.length
+          count
+        }
+        val totalLines = lines.sum
+        (key, listPairs.length, totalLines, files)
+    }
+    new LinesAnalyzer2Result(title, sources.length, byExt)
+  }
+}
+
+class LinesAnalyzer2Result(
+  titleArg: String,
+  totalFiles: Int,
+  byExt: Iterable[(String, Int, Int, Seq[File])])
+  extends AnalyzerResult {
+
+  override val title = titleArg + " lines"
+
+  override lazy val metrics = byExt.toSeq.flatMap {
+    case (ext, nFiles, nTotalLines, _) =>
+      val extPlus = if (ext.length > 0) ext else "(no ext)"
+      val pad = " " * (12 - extPlus.length)
+      Seq(new AnalyzerMetric(title + " " + extPlus + pad, nTotalLines, "lines"))
+  }
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.8-SNAPSHOT"
+version in ThisBuild := "1.0.9-SNAPSHOT"


### PR DESCRIPTION
We needed a tool like this for Apache Daffodil (incubating as of 2019-05-23)

There is one "daffodil-oriented" thing in here, which is that it 
looks at files for the double extension ".tdml.xml" and groups them
with files having extension ".tdml".

Only the FileAnalyzer special cases java and scala files now. All other analysis runs against
every file type. 

Just uses iso-8859-1 encoding to break files into lines. This eliminates decode errors when 
your files are not all in a uniform encoding. Encoding iso-8859-1 is the universal encoding. 
Every byte maps to a unicode character. Even if you open UTF-16 files with this encoding it 
will still count lines close to accurately.  Of course binary data files will have meaningless line counts. 

The output now looks like this:
[info] Code Statistics for project:
[info] Files Source
[info] - Total size: 4,510,174 Bytes
[info] - Avg size:   156,997 Bytes
[info] - Avg length: 3,750 lines
[info] - Total:      470 files
[info] - Scala:      428 files (91.1%)
[info] - Java:       6 files (1.3%)
[info] Lines Source
[info] - Total:      113,694 lines
[info] - Code:       69,702 lines (61.3%)
[info] - Comment:    30,205 lines (26.6%)
[info] - Blank:      13,787 lines (12.1%)
[info] - Bracket:    9,380 lines (8.3%)
[info] Chars Source
[info] - Total:      4,014,013 chars
[info] - Code:       2,673,718 chars (66.6%)
[info] - Comment:    1,340,295 chars (33.4%)
[info] Source lines
[info] - Source lines scala        99,242 lines
[info] - Source lines xsd          10,625 lines
[info] - Source lines tdml         2,395 lines
[info] - Source lines dtd          627 lines
[info] - Source lines java         360 lines
[info] - Source lines xsl          224 lines
[info] - Source lines css          85 lines
[info] - Source lines xml          79 lines
[info] - Source lines txt          57 lines
[info] - Source lines keep         0 lines
[info] Files Test
[info] - Total size: 8,034,664 Bytes
[info] - Avg size:   94,518 Bytes
[info] - Avg length: 2,289 lines
[info] - Total:      747 files
[info] - Scala:      245 files (32.8%)
[info] - Java:       4 files (0.5%)
[info] Lines Test
[info] - Total:      195,143 lines
[info] - Code:       164,078 lines (84.1%)
[info] - Blank:      21,662 lines (11.1%)
[info] - Comment:    9,403 lines (4.8%)
[info] - Bracket:    2,377 lines (1.2%)
[info] Chars Test
[info] - Total:      6,912,712 chars
[info] - Code:       6,474,835 chars (93.7%)
[info] - Comment:    437,877 chars (6.3%)
[info] Test lines
[info] - Test lines tdml         134,637 lines
[info] - Test lines scala        40,983 lines
[info] - Test lines xsd          16,761 lines
[info] - Test lines java         1,209 lines
[info] - Test lines xml          989 lines
[info] - Test lines dat          260 lines
[info] - Test lines txt          209 lines
[info] - Test lines (no ext)     93 lines
[info] - Test lines bin          2 lines
[info] - Test lines keep         0 lines
